### PR TITLE
Set Trivy output format to SARIF

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -53,8 +53,7 @@ jobs:
         uses: aquasecurity/trivy-action@0.2.2
         with:
           image-ref: '${{ env.SCAN_REF }}'
-          format: 'template'
-          template: '@/contrib/sarif.tpl'
+          format: 'sarif'
           output: 'trivy-results.sarif'
       - name: Upload Trivy scan results to GitHub Security tab
         uses: github/codeql-action/upload-sarif@v1

--- a/.github/workflows/scan_images.yaml
+++ b/.github/workflows/scan_images.yaml
@@ -44,8 +44,7 @@ jobs:
         uses: aquasecurity/trivy-action@0.2.2
         with:
           image-ref: '${{ env.IMAGE }}'
-          format: 'template'
-          template: '@/contrib/sarif.tpl'
+          format: 'sarif'
           output: 'trivy-results.sarif'
       - name: Upload Trivy scan results to GitHub Security tab
         uses: github/codeql-action/upload-sarif@v1


### PR DESCRIPTION
The "magic" template isn't needed any more with the latest
release. :smiley_cat: 