### PR TITLE
add ghcr badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Experiments with the Github Container Registry
 
+[![ghcr pulls](https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fraw.githubusercontent.com%2Fipitio%2Fghcr-pulls%2Fmaster%2Findex.json&query=%24%5B%3F(%40.owner%3D%3D%22airtower-luna%22%20%26%26%20%40.repo%3D%3D%22hello-ghcr%22%20%26%26%20%40.image%3D%3D%22hello-ghcr-meow%22)%5D.pulls&logo=github&label=pulls)](https://github.com/airtower-luna/hello-ghcr/pkgs/container/hello-ghcr-meow)
+
 Just trying things out here, the images are based on
 [`alpine`](https://hub.docker.com/_/alpine). Meow! :smile_cat:
 


### PR DESCRIPTION
ghcr.io's api doesn't let you see the pull count so I created [ghcr-pulls](https://github.com/ipitio/ghcr-pulls), a daily scraper that updates the count and makes this badge possible. I noticed that you use ghcr and made a tool for it and thought you might find this useful.