### PR TITLE
Trivy compromise reaction

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -16,7 +16,7 @@ permissions:
 
 jobs:
   build:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v6
       - name: Build container image

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -42,23 +42,6 @@ jobs:
               full_tag=ghcr.io/${CONTAINER_NAME}:${t}
               docker tag ${MEOW_ID} ${full_tag}
           done
-          echo "SCAN_REF=${full_tag}" >> ${GITHUB_ENV}
-      - name: Tag container image with temporary tag
-        if: ${{ ! env.TAGS }}
-        run: |
-          full_tag=ghcr.io/${CONTAINER_NAME}:${{ github.sha }}
-          docker tag ${MEOW_ID} ${full_tag}
-          echo "SCAN_REF=${full_tag}" >> ${GITHUB_ENV}
-      - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@0.35.0
-        with:
-          image-ref: '${{ env.SCAN_REF }}'
-          format: 'sarif'
-          output: 'trivy-results.sarif'
-      - name: Upload Trivy scan results to GitHub Security tab
-        uses: github/codeql-action/upload-sarif@v4
-        with:
-          sarif_file: 'trivy-results.sarif'
       - name: Docker login
         if: ${{ env.TAGS }}
         env:

--- a/.github/workflows/dependency_review.yaml
+++ b/.github/workflows/dependency_review.yaml
@@ -7,7 +7,7 @@ permissions:
 
 jobs:
   dependency-review:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: 'Checkout Repository'
         uses: actions/checkout@v6

--- a/.github/workflows/prune_images.yaml
+++ b/.github/workflows/prune_images.yaml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-python@v6
         with:
-          python-version: '3.12'
+          python-version: '3.14'
           cache: 'pip'
           cache-dependency-path: |
             .github/workflows/prune_images.yaml

--- a/.github/workflows/prune_images.yaml
+++ b/.github/workflows/prune_images.yaml
@@ -10,7 +10,7 @@ permissions:
 
 jobs:
   prune:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-python@v6

--- a/.github/workflows/scan_images.yaml
+++ b/.github/workflows/scan_images.yaml
@@ -1,3 +1,5 @@
+# Scan "latest" and "beta" images for vulnerabilities using Trivy
+# (https://github.com/aquasecurity/trivy-action).
 name: Scan existing images
 on:
   schedule:
@@ -41,7 +43,7 @@ jobs:
         with:
           ref: ${{ env.IMAGE_REF }}
       - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@0.35.0
+        uses: aquasecurity/trivy-action@v0.35.0
         with:
           image-ref: '${{ env.IMAGE }}'
           format: 'sarif'

--- a/.github/workflows/scan_images.yaml
+++ b/.github/workflows/scan_images.yaml
@@ -20,7 +20,7 @@ jobs:
           - 'latest'
           - 'beta'
     name: ${{ matrix.label }}
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Docker login
         env:

--- a/.github/workflows/scan_images.yaml
+++ b/.github/workflows/scan_images.yaml
@@ -2,6 +2,13 @@
 # (https://github.com/aquasecurity/trivy-action).
 name: Scan existing images
 on:
+  workflow_run:
+    workflows:
+      - Meow Container
+    types:
+      - completed
+    branches:
+      - main
   schedule:
     - cron: '10 3 * * SAT'
   workflow_dispatch:

--- a/.github/workflows/scan_images.yaml
+++ b/.github/workflows/scan_images.yaml
@@ -23,7 +23,6 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Docker login
-        if: ${{ env.TAGS }}
         env:
           GHCR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: >

--- a/README.md
+++ b/README.md
@@ -11,11 +11,6 @@ scripts here are supposed to do:
 * Choose suitable tags for the image (see
   [`tag-from-ref.py`](./tag-from-ref.py))
 
-* Scan the image for vulnerabilities using
-  [Trivy](https://github.com/aquasecurity/trivy-action). The scan also
-  runs regularly for the `beta` and `latest` tags in the
-  [`scan_images.yaml`](.github/workflows/scan_images.yaml) workflow.
-
 * If the image should be tagged, do that and push to GHCR.
 
 If you run the resulting image it'll meow at you, you can even give a


### PR DESCRIPTION
* Remove Trivy from build workflow (which has package write permissions)
* Use new tag with "v" prefix (though 0.35.0 was supposedly not compromised)
* Run scan workflow after build completes on `main`.

Also update workflow dependencies.